### PR TITLE
bumping types/vscode and vscode engine to 1.40.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,9 +133,9 @@
             "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
         },
         "@types/vscode": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.39.0.tgz",
-            "integrity": "sha512-rlg0okXDt7NjAyHXbZ2nO1I/VY/8y9w67ltLRrOxXQ46ayvrYZavD4A6zpYrGbs2+ZOEQzcUs+QZOqcVGQIxXQ==",
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
+            "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
             "dev": true
         },
         "agent-base": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "Tool"
     ],
     "engines": {
-        "vscode": "^1.39.0"
+        "vscode": "^1.40.0"
     },
     "categories": [
         "Other"
@@ -71,7 +71,7 @@
         "@types/node": "^12.12.7",
         "@types/sinon": "^7.5.0",
         "@types/sinon-chai": "^3.2.3",
-        "@types/vscode": "^1.39.0",
+        "@types/vscode": "^1.40.0",
         "assert": "^2.0.0",
         "chai": "^4.2.0",
         "gulp": "^4.0.2",


### PR DESCRIPTION
This replaces https://github.com/camel-tooling/vscode-wsdl2rest/pull/129

Signed-off-by: bfitzpat@redhat.com <bfitzpat@redhat.com>