### PR TITLE
FUSETOOLS2-350 - specify current latest compatible VS Code version for

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "postinstall": "node ./scripts/postinstall.js",
         "test": "node ./out/test/runTest.js",
         "lint": "tslint --project .",
-        "ui-test": "extest setup-and-run out/ui-test/extension.all.test.js"
+        "ui-test": "extest setup-and-run --code_version 1.43.2 out/ui-test/extension.all.test.js"
     },
     "devDependencies": {
         "@types/chai": "^4.2.11",


### PR DESCRIPTION
UI test 1.43.2

see https://github.com/redhat-developer/vscode-extension-tester/issues/92
for when 1.44.0 will be supported

Signed-off-by: Aurélien Pupier <apupier@redhat.com>