### PR TITLE
FUSETOOLS2-355 - Migrate ui tests to vscode-extension-tester 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -790,9 +790,9 @@
             "dev": true
         },
         "buffer": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-            "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
             "dev": true,
             "requires": {
                 "base64-js": "^1.0.2",
@@ -7026,15 +7026,15 @@
             }
         },
         "vscode-extension-tester": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-2.5.2.tgz",
-            "integrity": "sha512-78weOhHmVNxx1Htux8fPmx6Ds1IiWyB/eJwTeOB5zKwk+aO3G4erk27TVQKKCtF+wdSKSFFV+2cpeSIgF/FYkQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-2.6.0.tgz",
+            "integrity": "sha512-LGjV3fXOB+PPEASSOamGV0GqIXb8Eb4U3xfj5ktJdEOTSZiuHe+80/EsLoDuzbyu84w/6u4kL1P8frVTMGhOTw==",
             "dev": true,
             "requires": {
                 "@nut-tree/nut-js": "^1.3.1",
                 "@types/selenium-webdriver": "^3.0.15",
                 "clipboardy": "^2.0.0",
-                "commander": "^3.0.1",
+                "commander": "^5.0.0",
                 "compare-versions": "^3.5.1",
                 "fs-extra": "^8.1.0",
                 "glob": "^7.1.6",
@@ -7050,9 +7050,9 @@
             },
             "dependencies": {
                 "commander": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                    "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+                    "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
                     "dev": true
                 },
                 "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "postinstall": "node ./scripts/postinstall.js",
         "test": "node ./out/test/runTest.js",
         "lint": "tslint --project .",
-        "ui-test": "extest setup-and-run --code_version 1.43.2 out/ui-test/extension.all.test.js"
+        "ui-test": "extest setup-and-run out/ui-test/extension.all.test.js"
     },
     "devDependencies": {
         "@types/chai": "^4.2.11",
@@ -86,7 +86,7 @@
         "sinon-chai": "^3.5.0",
         "tslint": "^6.1.1",
         "typescript": "^3.8.3",
-        "vscode-extension-tester": "^2.5.2",
+        "vscode-extension-tester": "^2.6.0",
         "vscode-test": "^1.3.0",
         "vscode-uitests-tooling": "^2.0.0"
     },

--- a/src/ui-test/extension.test.ts
+++ b/src/ui-test/extension.test.ts
@@ -120,8 +120,7 @@ export function test(args: TestArguments) {
 
 		it(`Execute command: ${command.command}`, async function () {
 			this.timeout(6000);
-			const cmd = await CommandPalette.open();
-			await cmd.executeCommand(command.title);
+			await new Workbench().executeCommand(command.title);
 		});
 
 		it(`Open wsdl file [${args.type}]`, async function () {
@@ -129,10 +128,9 @@ export function test(args: TestArguments) {
 			switch (args.type) {
 				case 'url':
 					const input = await getInput();
-					input.test({
-						placeholder: 'Provide the URL for the WSDL file',
-						message: 'WSDL URL (Press \'Enter\' to confirm or \'Escape\' to cancel)'
-					});
+
+					expect(await input.getPlaceHolder()).to.be.equal('Provide the URL for the WSDL file');
+					expect(await input.getMessage()).to.be.equal('WSDL URL (Press \'Enter\' to confirm or \'Escape\' to cancel)');
 
 					await input.setText(WSDL_URL);
 					await input.confirm();
@@ -149,10 +147,8 @@ export function test(args: TestArguments) {
 		it(`Select '${args.framework}' option`, async function () {
 			const input = await getInput();
 
-			await input.test({
-				placeholder: 'Specify which DSL to generate the Camel configuration for',
-				quickPicks: ['Spring', 'Blueprint']
-			});
+			expect(await input.getPlaceHolder()).to.be.equal('Specify which DSL to generate the Camel configuration for');
+			expect(await getQuickPicks(input)).to.be.deep.equal(['Spring', 'Blueprint']);
 
 			await input.setText(args.framework);
 			await input.confirm();
@@ -161,11 +157,9 @@ export function test(args: TestArguments) {
 		it(`Confirm output directory`, async function () {
 			const input = await getInput();
 
-			await input.test({
-				placeholder: 'Enter the output directory for generated artifacts',
-				message: 'Output Directory (Press \'Enter\' to confirm or \'Escape\' to cancel)',
-				text: 'src/main/java'
-			});
+			expect(await input.getPlaceHolder()).to.be.equal('Enter the output directory for generated artifacts');
+			expect(await input.getMessage()).to.be.equal('Output Directory (Press \'Enter\' to confirm or \'Escape\' to cancel)');
+			expect(await input.getText()).to.be.equal('src/main/java');
 
 			await input.confirm();
 		});
@@ -173,10 +167,8 @@ export function test(args: TestArguments) {
 		it('Confirm JAX-WS endpoint', async function () {
 			const input = await getInput();
 
-			await input.test({
-				placeholder: 'Enter the address for the running jaxws endpoint (defaults to http://localhost:8080/somepath)',
-				message: 'JAXWS Endpoint (Press \'Enter\' to confirm or \'Escape\' to cancel)'
-			});
+			expect(await input.getPlaceHolder()).to.be.equal('Enter the address for the running jaxws endpoint (defaults to http://localhost:8080/somepath)');
+			expect(await input.getMessage()).to.be.equal('JAXWS Endpoint (Press \'Enter\' to confirm or \'Escape\' to cancel)');
 
 			await input.confirm();
 		});
@@ -184,10 +176,9 @@ export function test(args: TestArguments) {
 		it('Confirm JAX-RS endpoint', async function () {
 			const input = await getInput();
 
-			await input.test({
-				placeholder: 'Enter the address for the jaxrs endpoint (defaults to http://localhost:8081/jaxrs)',
-				message: 'JAXRS Endpoint (Press \'Enter\' to confirm or \'Escape\' to cancel)'
-			});
+
+			expect(await input.getPlaceHolder()).to.be.equal('Enter the address for the jaxrs endpoint (defaults to http://localhost:8081/jaxrs)');
+			expect(await input.getMessage()).to.be.equal('JAXRS Endpoint (Press \'Enter\' to confirm or \'Escape\' to cancel)');
 
 			await input.setText('http://localhost:8000/jaxrs');
 			await input.confirm();
@@ -444,7 +435,11 @@ function getExpectedFileList(args: TestArguments): string[] {
 	return files;
 }
 
-async function getInput(): Promise<Input> {
-	await InputBox.create();
-	return Input.getInstance();
+async function getInput(): Promise<InputBox> {
+	return InputBox.create();
 } 
+
+async function getQuickPicks(input: InputBox) {
+	const quickPicks = await input.getQuickPicks();
+	return Promise.all(quickPicks.map(async (q) => await q.getText()));
+}

--- a/src/ui-test/marketplace.test.ts
+++ b/src/ui-test/marketplace.test.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { CommandPalette, DefaultWait, Marketplace } from 'vscode-uitests-tooling';
-import { EditorView, ExtensionsViewItem } from 'vscode-extension-tester';
+import { DefaultWait, Marketplace } from 'vscode-uitests-tooling';
+import { EditorView, ExtensionsViewItem, InputBox, Workbench } from 'vscode-extension-tester';
 import { expect } from 'chai';
 import { getPackageData, PackageData } from './package_data';
 
@@ -63,7 +63,7 @@ export function test() {
 		});
 
 		it('Registered all commands', async function () {
-			const cmd = await CommandPalette.open();
+			const cmd = await new Workbench().openCommandPrompt() as InputBox;
 			await cmd.setText('>wsdl2rest');
 			// wait for suggestions to show
 			await DefaultWait.sleep(750);


### PR DESCRIPTION
Update ui tests to be compatible with latest vscode and vscode-extension-tester.

Signed-off-by: Marian Lorinc <mlorinc@redhat.com>