### PR TITLE
FUSETOOLS2-490 - use rhel8 instead of rhel 7 node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
 	stage('Checkout repo') {
 		deleteDir()
 		git url: 'https://github.com/camel-tooling/vscode-wsdl2rest'
@@ -54,7 +54,7 @@ node('rhel7'){
     }
 }
 
-node('rhel7'){
+node('rhel8'){
 	if(publishToMarketPlace.equals('true')){
 		timeout(time:5, unit:'DAYS') {
 			input message:'Approve deployment?', submitter: 'apupier,lheinema,bfitzpat,tsedmik,djelinek'


### PR DESCRIPTION
to workaround microsoft/vscode#99492

Signed-off-by: Aurélien Pupier <apupier@redhat.com>