### PR TITLE
FUSETOOLS2-603 - switch back from rhel 8 to rhel 7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel8'){
+node('rhel7'){
 	stage('Checkout repo') {
 		deleteDir()
 		git url: 'https://github.com/camel-tooling/vscode-wsdl2rest'
@@ -54,7 +54,7 @@ node('rhel8'){
     }
 }
 
-node('rhel8'){
+node('rhel7'){
 	if(publishToMarketPlace.equals('true')){
 		timeout(time:5, unit:'DAYS') {
 			input message:'Approve deployment?', submitter: 'apupier,lheinema,bfitzpat,tsedmik,djelinek'


### PR DESCRIPTION
to workaround SIGSEV of VS Code on Jenkins CI due to
https://github.com/microsoft/vscode/issues/104988

Signed-off-by: Aurélien Pupier <apupier@redhat.com>