### PR TITLE
FUSETOOLS2-704 - use npm ci instead of npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - 'npm install -g mocha'
   - 'mvn install -f ./wsdl2rest/pom.xml'
 install:
-  - 'npm install'
+  - 'npm ci'
   # https://github.com/travis-ci/travis-ci/issues/8813
   - 'rm -f ./node_modules/.bin/which'
   - 'npm run vscode:prepublish'
@@ -25,7 +25,7 @@ after_success:
 cache:
   directories:
     - "$HOME/.m2"
-    - "node_modules"
+    - "$HOME/.npm"
 env: DISPLAY=:99
 branches:
   except:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ node('rhel8'){
 		
 		sh "mvn install -f ./wsdl2rest/pom.xml"
 		sh "npm install --ignore-scripts"
-		sh "npm install"
+		sh "npm ci"
 		sh "npm run vscode:prepublish"
 	}
 


### PR DESCRIPTION
it allows to ensure that the package-lock.json is respected

Signed-off-by: Aurélien Pupier <apupier@redhat.com>