### PR TITLE
FUSETOOLS2-872 - fix unstable UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test-resources/
 .factorypath
 src/ui-test/runtimes/**/target
 .test-extensions
+.ui-testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,15 @@
             "integrity": "sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw==",
             "dev": true
         },
+        "@types/fs-extra": {
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.8.tgz",
+            "integrity": "sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/mocha": {
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
@@ -335,9 +344,9 @@
             "dev": true
         },
         "arch": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-            "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+            "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
             "dev": true
         },
         "archy": {
@@ -570,23 +579,13 @@
             "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
         "azure-devops-node-api": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-            "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
             "dev": true,
             "requires": {
-                "os": "0.1.1",
-                "tunnel": "0.0.4",
-                "typed-rest-client": "1.2.0",
-                "underscore": "1.8.3"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
+                "tunnel": "0.0.6",
+                "typed-rest-client": "^1.8.4"
             }
         },
         "bach": {
@@ -951,31 +950,39 @@
             "dev": true
         },
         "cheerio": {
-            "version": "1.0.0-rc.5",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.5.tgz",
-            "integrity": "sha512-yoqps/VCaZgN4pfXtenwHROTp8NG6/Hlt4Jpz2FEP0ZJQ+ZUkVDd0hAPDNKhj3nakpfPt/CNs57yEtxD1bXQiw==",
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
+            "integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
             "dev": true,
             "requires": {
-                "cheerio-select-tmp": "^0.1.0",
-                "dom-serializer": "~1.2.0",
-                "domhandler": "^4.0.0",
-                "entities": "~2.1.0",
-                "htmlparser2": "^6.0.0",
-                "parse5": "^6.0.0",
-                "parse5-htmlparser2-tree-adapter": "^6.0.0"
+                "cheerio-select": "^1.4.0",
+                "dom-serializer": "^1.3.1",
+                "domhandler": "^4.2.0",
+                "htmlparser2": "^6.1.0",
+                "parse5": "^6.0.1",
+                "parse5-htmlparser2-tree-adapter": "^6.0.1",
+                "tslib": "^2.2.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+                    "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+                    "dev": true
+                }
             }
         },
-        "cheerio-select-tmp": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.1.tgz",
-            "integrity": "sha512-YYs5JvbpU19VYJyj+F7oYrIE2BOll1/hRU7rEy/5+v9BzkSo3bK81iAeeQEMI92vRIxz677m72UmJUiVwwgjfQ==",
+        "cheerio-select": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
+            "integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
             "dev": true,
             "requires": {
-                "css-select": "^3.1.2",
-                "css-what": "^4.0.0",
-                "domelementtype": "^2.1.0",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.4.4"
+                "css-select": "^4.1.2",
+                "css-what": "^5.0.0",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0",
+                "domutils": "^2.6.0"
             }
         },
         "child_process": {
@@ -1075,36 +1082,14 @@
             "dev": true
         },
         "clone-deep": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-            "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.3",
-                "is-plain-object": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "lazy-cache": "^1.0.3",
-                "shallow-clone": "^0.1.2"
-            },
-            "dependencies": {
-                "for-own": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-                    "dev": true,
-                    "requires": {
-                        "for-in": "^1.0.1"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
             }
         },
         "clone-stats": {
@@ -1370,22 +1355,22 @@
             }
         },
         "css-select": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
-            "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
+            "integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
             "dev": true,
             "requires": {
                 "boolbase": "^1.0.0",
-                "css-what": "^4.0.0",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.4.3",
+                "css-what": "^5.0.0",
+                "domhandler": "^4.2.0",
+                "domutils": "^2.6.0",
                 "nth-check": "^2.0.0"
             }
         },
         "css-what": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-            "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
+            "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
             "dev": true
         },
         "d": {
@@ -1559,40 +1544,40 @@
             "dev": true
         },
         "dom-serializer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-            "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+            "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0",
+                "domhandler": "^4.2.0",
                 "entities": "^2.0.0"
             }
         },
         "domelementtype": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
             "dev": true
         },
         "domhandler": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-            "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+            "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
             "dev": true,
             "requires": {
-                "domelementtype": "^2.1.0"
+                "domelementtype": "^2.2.0"
             }
         },
         "domutils": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-            "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+            "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
             "dev": true,
             "requires": {
                 "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0"
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
             }
         },
         "duplexer2": {
@@ -1651,9 +1636,9 @@
             }
         },
         "entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
             "dev": true
         },
         "error-ex": {
@@ -2195,545 +2180,14 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.12.1",
-                "node-pre-gyp": "^0.12.0"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "minipass": {
-                    "version": "2.3.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "needle": {
-                    "version": "2.3.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "^4.1.0",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.12.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.1",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.2.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "npm-packlist": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "^0.6.0",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "5.7.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "4.4.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "chownr": "^1.1.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.4",
-                        "minizlib": "^1.1.1",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "wide-align": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "^1.0.2 || 2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "yallist": {
-                    "version": "3.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                }
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
             }
         },
         "fstream": {
@@ -2948,9 +2402,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.1.15",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "growl": {
             "version": "1.10.5",
@@ -3120,14 +2574,14 @@
             "dev": true
         },
         "htmlparser2": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
-            "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.0.0",
-                "domutils": "^2.4.4",
+                "domutils": "^2.5.2",
                 "entities": "^2.0.0"
             }
         },
@@ -3377,9 +2831,9 @@
             }
         },
         "is-docker": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
             "dev": true
         },
         "is-extendable": {
@@ -3704,9 +3158,9 @@
             "dev": true
         },
         "kind-of": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
         "last-run": {
@@ -3718,12 +3172,6 @@
                 "default-resolution": "^2.0.0",
                 "es6-weak-map": "^2.0.1"
             }
-        },
-        "lazy-cache": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-            "dev": true
         },
         "lazystream": {
             "version": "1.0.0",
@@ -4008,27 +3456,6 @@
                 }
             }
         },
-        "merge-deep": {
-            "version": "github:jrichter1/merge-deep#9ffe23b32f281de41bce111e8c38294d96fed34e",
-            "from": "github:jrichter1/merge-deep#functions",
-            "dev": true,
-            "requires": {
-                "arr-union": "^3.1.0",
-                "clone-deep": "^0.2.4",
-                "kind-of": "^3.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "micromatch": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -4127,24 +3554,6 @@
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
-                }
-            }
-        },
-        "mixin-object": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-            "dev": true,
-            "requires": {
-                "for-in": "^0.1.3",
-                "is-extendable": "^0.1.1"
-            },
-            "dependencies": {
-                "for-in": {
-                    "version": "0.1.8",
-                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
-                    "dev": true
                 }
             }
         },
@@ -4520,15 +3929,15 @@
             }
         },
         "monaco-page-objects": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.4.2.tgz",
-            "integrity": "sha512-XcZ8ZCAUTfRdr6ZDanBQ2JIipP0YtTcdoBCNHlen6ZkKd1a8YoWJvn86fbJ2wxSe3w0orHvQcGAT/fBWIKZ3iQ==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.5.3.tgz",
+            "integrity": "sha512-JXDLVDxVTfUrqvbG9BciPg4BXFbmCROT7VQBWO7J8aeOUQirRlLhFRM96aALomCyQDaC1Sp/kl5ZITox6OVHJQ==",
             "dev": true,
             "requires": {
                 "clipboardy": "^2.0.0",
+                "clone-deep": "^4.0.1",
                 "compare-versions": "^3.5.1",
                 "fs-extra": "^9.0.1",
-                "merge-deep": "github:jrichter1/merge-deep#functions",
                 "ts-essentials": "^7.0.0"
             },
             "dependencies": {
@@ -4543,12 +3952,6 @@
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
                     }
-                },
-                "graceful-fs": {
-                    "version": "4.2.6",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-                    "dev": true
                 }
             }
         },
@@ -4677,9 +4080,9 @@
             }
         },
         "node-abi": {
-            "version": "2.19.3",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-            "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
+            "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
             "dev": true,
             "requires": {
                 "semver": "^5.4.1"
@@ -4958,12 +4361,6 @@
             "requires": {
                 "readable-stream": "^2.0.1"
             }
-        },
-        "os": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -5275,9 +4672,9 @@
                     }
                 },
                 "bl": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-                    "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+                    "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
                     "dev": true,
                     "requires": {
                         "buffer": "^5.5.0",
@@ -5355,9 +4752,9 @@
                     }
                 },
                 "tar-stream": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-                    "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+                    "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
                     "dev": true,
                     "requires": {
                         "bl": "^4.0.3",
@@ -5786,32 +5183,12 @@
             "dev": true
         },
         "shallow-clone": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-            "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
             "dev": true,
             "requires": {
-                "is-extendable": "^0.1.1",
-                "kind-of": "^2.0.1",
-                "lazy-cache": "^0.2.3",
-                "mixin-object": "^2.0.1"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                    "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.0.2"
-                    }
-                },
-                "lazy-cache": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-                    "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-                    "dev": true
-                }
+                "kind-of": "^6.0.2"
             }
         },
         "shebang-command": {
@@ -5828,6 +5205,25 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
+        },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            },
+            "dependencies": {
+                "object-inspect": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+                    "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+                    "dev": true
+                }
+            }
         },
         "signal-exit": {
             "version": "3.0.3",
@@ -6462,6 +5858,12 @@
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
             "dev": true
         },
+        "tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true
+        },
         "truncate-utf8-bytes": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -6522,9 +5924,9 @@
             }
         },
         "tunnel": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
             "dev": true
         },
         "tunnel-agent": {
@@ -6553,19 +5955,29 @@
             "dev": true
         },
         "typed-rest-client": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-            "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+            "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
             "dev": true,
             "requires": {
-                "tunnel": "0.0.4",
-                "underscore": "1.8.3"
+                "qs": "^6.9.1",
+                "tunnel": "0.0.6",
+                "underscore": "^1.12.1"
             },
             "dependencies": {
+                "qs": {
+                    "version": "6.10.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+                    "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+                    "dev": true,
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
+                },
                 "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+                    "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
                     "dev": true
                 }
             }
@@ -6915,12 +6327,12 @@
             }
         },
         "vsce": {
-            "version": "1.85.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.85.0.tgz",
-            "integrity": "sha512-YVFwjXWvHRwk75mm3iL4Wr3auCdbBPTv2amtLf97ccqH0hkt0ZVBddu7iOs4HSEbSr9xiiaZwQHUsqMm6Ks0ag==",
+            "version": "1.88.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.88.0.tgz",
+            "integrity": "sha512-FS5ou3G+WRnPPr/tWVs8b/jVzeDacgZHy/y7/QQW7maSPFEAmRt2bFGUJtJVEUDLBqtDm/3VGMJ7D31cF2U1tw==",
             "dev": true,
             "requires": {
-                "azure-devops-node-api": "^7.2.0",
+                "azure-devops-node-api": "^10.2.2",
                 "chalk": "^2.4.2",
                 "cheerio": "^1.0.0-rc.1",
                 "commander": "^6.1.0",
@@ -6936,7 +6348,7 @@
                 "read": "^1.0.7",
                 "semver": "^5.1.0",
                 "tmp": "0.0.29",
-                "typed-rest-client": "1.2.0",
+                "typed-rest-client": "^1.8.4",
                 "url-join": "^1.1.0",
                 "yauzl": "^2.3.1",
                 "yazl": "^2.2.2"
@@ -6960,9 +6372,9 @@
             }
         },
         "vscode-extension-tester": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-3.2.6.tgz",
-            "integrity": "sha512-yhPkfUpgCxK5AdeqW0gsvDRquBixGgTb2BC6RgdaXHvi9pna7nomlwzDeLWNZkiT2p+Rg+bcF61ftggMER2gcQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-4.0.3.tgz",
+            "integrity": "sha512-Bd4VelzQPJ5ogxEVwPR5dG7FyesgmAi2tqE74qlhTIgIIpQhZg7JlYEf2rRb6wWm/8b/s9LSSuls0QjhfLLOzQ==",
             "dev": true,
             "requires": {
                 "@types/selenium-webdriver": "^3.0.15",
@@ -6971,14 +6383,14 @@
                 "fs-extra": "^9.0.1",
                 "glob": "^7.1.6",
                 "js-yaml": "^3.13.1",
-                "monaco-page-objects": "^1.4.2",
+                "monaco-page-objects": "^1.5.3",
                 "request": "^2.88.0",
                 "sanitize-filename": "^1.6.3",
                 "selenium-webdriver": "^3.0.0",
                 "targz": "^1.0.1",
                 "unzip-stream": "^0.3.0",
                 "vsce": "^1.81.0",
-                "vscode-extension-tester-locators": "^1.53.0"
+                "vscode-extension-tester-locators": "^1.54.2"
             },
             "dependencies": {
                 "commander": {
@@ -7000,9 +6412,9 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "version": "7.1.7",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -7012,19 +6424,13 @@
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
                     }
-                },
-                "graceful-fs": {
-                    "version": "4.2.6",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-                    "dev": true
                 }
             }
         },
         "vscode-extension-tester-locators": {
-            "version": "1.53.0",
-            "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.53.0.tgz",
-            "integrity": "sha512-/ObRO+/W3YLVFuH10qbSYivvBsXy+1z564Ka8H8HJ5TJBf0SG1IJzdJe2ocyeosD4OQLoNOWPhhQdrhZoHUkxw==",
+            "version": "1.54.2",
+            "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.54.2.tgz",
+            "integrity": "sha512-N7R8s5Zq2ONIRc83UHziEFobDN8bjetaC8TKO47JZRV7dzo/6/f4dLzoO8m7Z4x58VNo+H2/DxW3gq37wIaBfg==",
             "dev": true
         },
         "vscode-extension-tester-native": {
@@ -7049,12 +6455,6 @@
                         "jsonfile": "^6.0.1",
                         "universalify": "^2.0.0"
                     }
-                },
-                "graceful-fs": {
-                    "version": "4.2.6",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-                    "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-                    "dev": true
                 }
             }
         },
@@ -7106,10 +6506,45 @@
             }
         },
         "vscode-uitests-tooling": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-2.0.1.tgz",
-            "integrity": "sha512-AIWHk5Fg9VIEvOsj47lAnXlIa5hZUXpORdjGZ5aXhWDX7Et29JXVDQCG89jKdJtZ+MKTA3BaQn68vGXcTS7fgQ==",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-uitests-tooling/-/vscode-uitests-tooling-2.1.0.tgz",
+            "integrity": "sha512-r7g5I4P6mtgS7bJ3/0yqdgDHHQ9jAp2It0nuUK1CS03PNVmQRUHCvKUTP/XtjaI4QnR/ScIR1ofvet/uJXY+Yg==",
+            "dev": true,
+            "requires": {
+                "chai": "^4.2.0",
+                "clipboardy": "^2.3.0",
+                "fs-extra": "^8.1.0",
+                "sanitize-filename": "^1.6.3",
+                "tree-kill": "^1.2.2"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
+                    }
+                },
+                "universalify": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+                    "dev": true
+                }
+            }
         },
         "which": {
             "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     },
     "devDependencies": {
         "@types/chai": "^4.2.18",
+        "@types/fs-extra": "^9.0.8",
         "@types/mocha": "^8.2.2",
         "@types/node": "^15.6.1",
         "@types/sinon": "^10.0.1",
@@ -86,10 +87,10 @@
         "sinon-chai": "^3.7.0",
         "tslint": "^6.1.3",
         "typescript": "^4.3.2",
-        "vscode-extension-tester": "^3.2.6",
+        "vscode-extension-tester": "^4.0.3",
         "vscode-extension-tester-native": "^3.0.2",
         "vscode-test": "^1.5.2",
-        "vscode-uitests-tooling": "^2.0.1"
+        "vscode-uitests-tooling": "^2.1.0"
     },
     "dependencies": {
         "child_process": "^1.0.2",

--- a/src/ui-test/extension.all.test.ts
+++ b/src/ui-test/extension.all.test.ts
@@ -15,36 +15,32 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
-import * as extensionTest from './extension.test';
-import * as fs from 'fs';
-import * as installTest from './install.test';
-import * as marketplaceTest from './marketplace.test';
-import * as path from 'path';
-import * as webserver from '../test/app_soap';
-import { expect } from 'chai';
-import { DefaultWait, Project } from 'vscode-uitests-tooling';
-import { projectPath } from './package_data';
-import { VSBrowser } from 'vscode-extension-tester';
+ import * as assert from 'assert';
+ import * as extensionTest from './extension.test';
+ import * as fs from 'fs';
+ import * as installTest from './install.test';
+ import * as marketplaceTest from './marketplace.test';
+ import * as path from 'path';
+ import * as webserver from '../test/app_soap';
+ import { projectPath } from './package_data';
+ import { EditorView, VSBrowser } from 'vscode-extension-tester';
+ import { after, before } from "vscode-uitests-tooling";
 
 describe('All tests', function () {
 	installTest.test();
 	marketplaceTest.test();
 
-	describe('Extension tests', function() {
-		this.timeout(4000);
+	describe('Extension tests', function () {
+		this.timeout(60000);
 		let browser: VSBrowser;
-		let workspace: Project;
 
-		before('Setup environment', async function() {
-			this.timeout(32000);
+		before('Setup environment', async function () {
 			browser = VSBrowser.instance;
-			workspace = await prepareWorkspace(browser);
 			webserver.startWebService();
+			await new EditorView().closeAllEditors();
 		});
 
-		after('Clear environment', async function() {
-			await clearWorkspace(workspace);
+		after('Clear environment', async function () {
 			webserver.stopWebService();
 		});
 
@@ -76,29 +72,4 @@ function* walk(dir: string): Iterable<string> {
 			yield file;
 		}
 	}
-}
-
-/**
- * Creates new project and opens it in vscode
- */
-async function prepareWorkspace(browser: VSBrowser): Promise<Project> {
-	const project = new Project(extensionTest.WORKSPACE_PATH);
-	
-	expect(project.exists, `Test directory (${extensionTest.WORKSPACE_PATH}) already exists. In order to run this test, delete '${extensionTest.WORKSPACE_PATH}' directory.`).to.be.false;
-	project.create();
-	expect(project.exists, `Could not create test directory (${extensionTest.WORKSPACE_PATH}).`).to.be.true;
-
-	await project.open();
-	await DefaultWait.sleep(12000);
-
-	return project;
-}
-
-/**
- * Closes and deletes project
- * @param workspace project object returned from `prepareWorkspace` function
- */
-async function clearWorkspace(workspace: Project): Promise<void> {
-	await workspace.close();
-	await workspace.delete();
 }

--- a/src/ui-test/marketplace.test.ts
+++ b/src/ui-test/marketplace.test.ts
@@ -15,45 +15,36 @@
  * limitations under the License.
  */
 
-import { DefaultWait, Marketplace } from 'vscode-uitests-tooling';
+import { after, before, DefaultWait, Marketplace, Workbench } from 'vscode-uitests-tooling';
 import {
 	EditorView,
 	ExtensionsViewItem,
-	ExtensionsViewSection,
-	InputBox,
-	SideBarView,
-	Workbench,
+	InputBox
 } from 'vscode-extension-tester';
 import { expect } from 'chai';
 import { getPackageData, PackageData } from './package_data';
 
 export function test() {
 	describe('Marketplace extension test', function () {
-		this.timeout(3500);
+		this.timeout(60000);
 		let packageData: PackageData;
 		let marketplace: Marketplace;
-		let section: ExtensionsViewSection;
 		let wsdl2restExtension: ExtensionsViewItem;
 
 		before('Init tester and get package data', async function () {
-			this.timeout(10000);
+			this.retries(3);
 			packageData = getPackageData();
-			marketplace = await Marketplace.open();
-			section = (await new SideBarView().getContent().getSection('Installed')) as ExtensionsViewSection;
+			marketplace = await Marketplace.open(this.timeout() - 1000);
 		});
 
 		after('Clear workspace', async function () {
-			await section.clearSearch();
-			await Promise.all([
-				marketplace.close(),
-				new EditorView().closeAllEditors()
-			]);
+			await marketplace?.clearSearch(this.timeout() - 1000);
+			await new EditorView().closeAllEditors();
 		});
 
 		it('Find extension', async function () {
-			this.timeout(10000);
 			await DefaultWait.sleep(1000);
-			wsdl2restExtension = await section.findItem(`@installed ${packageData.displayName}`);
+			wsdl2restExtension = await marketplace.findExtension(`@installed ${packageData.displayName}`, this.timeout() - 1000);
 			expect(wsdl2restExtension).not.to.be.undefined;
 		});
 

--- a/src/ui-test/uitest_runner.ts
+++ b/src/ui-test/uitest_runner.ts
@@ -38,7 +38,10 @@ async function main(): Promise<void> {
     await tester.downloadCode(vscodeVersion);
     await tester.downloadChromeDriver(vscodeVersion);
 
-    await tester.runTests('out/ui-test/extension.all.test.js', vscodeVersion);
+    await tester.runTests('out/ui-test/extension.all.test.js', {
+        vscodeVersion,
+        settings: 'src/ui-test/vscode-settings.json'
+    });
 }
 
 main();

--- a/src/ui-test/vscode-settings.json
+++ b/src/ui-test/vscode-settings.json
@@ -1,0 +1,14 @@
+{
+    "files.exclude": {
+        "out": false
+    },
+    "search.exclude": {
+        "out": true
+    },
+    "files.simpleDialog.enable": true,
+    "window.titleBarStyle": "custom",
+    "workbench.editor.enablePreview": false,
+    "window.restoreFullscreen": true,
+    "window.newWindowDimensions": "maximized",
+    "window.title": "${dirty}${activeEditorLong}${separator}${rootPath}${separator}${appName}"
+}


### PR DESCRIPTION
Change log:

- native dialog is no longer used
- folder is opened for each generated project (it fixes problems with Windows file lock)
- added input checks to increase stability
- replaced ExtensionViewSection with Marketplace class from vscode-uitests-tooling
- changed test timers
- changed test case titles to be more file name friendly

Signed-off-by: Marian Lorinc <mlorinc@redhat.com>