### PR TITLE
FUSETOOLS-1157 - disable workspace trust in Ui test as workaround

### DIFF
--- a/src/ui-test/vscode-settings.json
+++ b/src/ui-test/vscode-settings.json
@@ -10,5 +10,6 @@
     "workbench.editor.enablePreview": false,
     "window.restoreFullscreen": true,
     "window.newWindowDimensions": "maximized",
-    "window.title": "${dirty}${activeEditorLong}${separator}${rootPath}${separator}${appName}"
+    "window.title": "${dirty}${activeEditorLong}${separator}${rootPath}${separator}${appName}",
+    "security.workspace.trust.enabled": false
 }


### PR DESCRIPTION
until it is handled in VS Code Extension tester
https://github.com/redhat-developer/vscode-extension-tester/issues/295

it is a workaround to fix the UI tests on master branch which is broken since VS Code 1.57 has been released