### PR TITLE
Include reviewers also for the Maven part of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  reviewers:
+  - apupier
+  - bfitzpat
+  - lhein


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>