### PR TITLE
Revert "FUSETOOLS-1157 - disable workspace trust in Ui test as

### DIFF
--- a/src/ui-test/vscode-settings.json
+++ b/src/ui-test/vscode-settings.json
@@ -10,6 +10,5 @@
     "workbench.editor.enablePreview": false,
     "window.restoreFullscreen": true,
     "window.newWindowDimensions": "maximized",
-    "window.title": "${dirty}${activeEditorLong}${separator}${rootPath}${separator}${appName}",
-    "security.workspace.trust.enabled": false
+    "window.title": "${dirty}${activeEditorLong}${separator}${rootPath}${separator}${appName}"
 }


### PR DESCRIPTION
workaround"

This reverts commit 83138e136ff21f62f9d31908527fe30246301d44.

it has been fixed in vscode-extension-tester

Signed-off-by: Aurélien Pupier <apupier@redhat.com>