### PR TITLE
FUSETOOLS2-1359 - fix main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 job_default: &job_defaults
   working_directory: ~/vscode-wsdl2rest
   docker:
-    - image: circleci/openjdk:8-jdk-node-browsers
+    - image: circleci/openjdk:8-jdk-browsers
 
 common_env: &common_env
   MAVEN_OPTS: -Xmx512m
@@ -17,6 +17,14 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}-{{ checksum "./wsdl2rest/pom.xml" }}
+      - run:
+          name: Install Node environment
+          command: |
+            curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+      - run:
+          name: Setup environment for global npm dependencies
+          command: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
       - run:
           name: install-typescript
           command: npm install --prefix=$HOME/.local -g typescript

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,13 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}-{{ checksum "./wsdl2rest/pom.xml" }}
       - run:
           name: install-typescript
-          command: sudo npm install -g typescript
+          command: npm install --prefix=$HOME/.local -g typescript
       - run:
           name: install-mocha
-          command: sudo npm install -g mocha
+          command: npm install --prefix=$HOME/.local -g mocha
       - run:
           name: install-vsce
-          command: sudo npm install -g vsce
+          command: npm install --prefix=$HOME/.local -g vsce
       - run:
           name: npm-ci
           command: npm ci


### PR DESCRIPTION
on Circle CI

it was previously required, now it is causing build failures.
see https://stackoverflow.com/questions/50915469/simple-circleci-2-0-configuration-fails-for-global-npm-package-installation
for workaround

Signed-off-by: Aurélien Pupier <apupier@redhat.com>