### PR TITLE
FUSETOOLS2-1587 - fix upload to download.jboss.org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,11 +46,11 @@ node('rhel8'){
 	if(params.UPLOAD_LOCATION) {
 		stage('Snapshot') {
 			def filesToPush = findFiles(glob: '**.vsix')
-			sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${filesToPush[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-wsdl2rest/"
+			sh "sftp -C ${UPLOAD_LOCATION}/snapshots/vscode-wsdl2rest/ <<< \$'put -p -r ${filesToPush[0].path}'"
             stash name:'vsix', includes:filesToPush[0].path
             def tgzFilesToPush = findFiles(glob: '**.tgz')
             stash name:'tgz', includes:tgzFilesToPush[0].path
-            sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${tgzFilesToPush[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-wsdl2rest/"
+            sh "sftp -C ${UPLOAD_LOCATION}/snapshots/vscode-wsdl2rest/ <<< \$'put -p -r ${tgzFilesToPush[0].path}'"
 		}
     }
 }
@@ -72,9 +72,9 @@ node('rhel8'){
 
             stage "Promote the build to stable"
             def vsix = findFiles(glob: '**.vsix')
-            sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/stable/vscode-wsdl2rest/"
+            sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-wsdl2rest/ <<< \$'put -p -r ${vsix[0].path}'"
             def tgz = findFiles(glob: '**.tgz')
-            sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${tgz[0].path} ${UPLOAD_LOCATION}/stable/vscode-wsdl2rest/"
+            sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-wsdl2rest/ <<< \$'put -p -r ${tgz[0].path}'"
             
             sh "npm install -g ovsx"
 		    withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {


### PR DESCRIPTION
rsync is now no more recommended and requires extra parameters.
Replacing by sftp which is the recommended way.

Following recommended PR on other project
https://github.com/redhat-developer/vscode-wizard/pull/103

Signed-off-by: Aurélien Pupier <apupier@redhat.com>